### PR TITLE
update livebook docker image

### DIFF
--- a/mac_with_livebook/docker-compose.yml
+++ b/mac_with_livebook/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     volumes:
       - dbdata:/var/lib/postgresql/data
   livebook:
-    image: livebook/livebook
+    image: ghcr.io/livebook-dev/livebook
     volumes:
       - ./livebook:/data
     ports:

--- a/mixed_with_livebook/docker-compose.yml
+++ b/mixed_with_livebook/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     volumes:
       - dbdata:/var/lib/postgresql/data
   livebook:
-    image: livebook/livebook
+    image: ghcr.io/livebook-dev/livebook
     volumes:
       - ./livebook:/data
     ports:

--- a/non_mac_with_livebook/docker-compose.yml
+++ b/non_mac_with_livebook/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     volumes:
       - dbdata:/var/lib/postgresql/data
   livebook:
-    image: livebook/livebook
+    image: ghcr.io/livebook-dev/livebook
     volumes:
       - ./livebook:/data
     ports:


### PR DESCRIPTION
### Description

It seems like Livebook team has moved their image repositories from Dockerhub to Github. The Dockerhub repository does not have latest images. So it would be nice to update our `docker-compose.yml` files with the new repository location. Hope this helps!

### Changes

- replace [livebook/livebook] (old repository) with [ghcr.io/livebook-dev/livebook] (new repository)


### Notes

- We could alternatively specify a Livebook version like `ghcr.io/livebook-dev/livebook:0.11.3`.
- related article: [Elixir Livebook の Docker イメージの在処](https://qiita.com/mnishiguchi/items/93fca196918f911b3c2d)

[ghcr.io/livebook-dev/livebook]: https://github.com/livebook-dev/livebook/pkgs/container/livebook
[livebook/livebook]: https://hub.docker.com/r/livebook/livebook/tags