### PR TITLE
add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+sample/
+docker-compose.override.yml


### PR DESCRIPTION
From developer's persipective, it would be convenient to exclude generated files from our git history.

I noticed a couple of file files getting generated following the instructions in READMEs.
- `.env`
- `docker-compose.override.yml`

Also we might want to exclude `sample` as well.

One benefit of ignoring those files is it will allow us to focus on the core logic of this project.